### PR TITLE
Update example to use recent Flutter HEAD

### DIFF
--- a/src/examples/mesh/mesh_example.cc
+++ b/src/examples/mesh/mesh_example.cc
@@ -144,7 +144,7 @@ bool MeshExample::Setup(impeller::Context& context) {
   auto pipeline_desc =
       impeller::PipelineBuilder<VS, FS>::MakeDefaultPipelineDescriptor(context);
   pipeline_desc->SetSampleCount(impeller::SampleCount::kCount4);
-  pipeline_desc->SetWindingOrder(impeller::WindingOrder::kCounterClockwise);
+  pipeline_desc->SetWindingOrder(impeller::WindingOrder::kClockwise);
   pipeline_desc->SetCullMode(impeller::CullMode::kBackFace);
   pipeline_desc->SetDepthStencilAttachmentDescriptor(
     std::make_optional<impeller::DepthAttachmentDescriptor>({
@@ -185,8 +185,8 @@ bool MeshExample::Render(impeller::Context& context,
   VS::VertInfo vs_uniform;
   vs_uniform.mvp =
       impeller::Matrix::MakePerspective(impeller::Degrees{60},
-                                        pass->GetRenderTargetSize(), 10, 100) *
-      impeller::Matrix::MakeTranslation({0, 0, -50}) *
+                                        pass->GetRenderTargetSize(), 0.1, 1000) *
+      impeller::Matrix::MakeLookAt({0, 0, -50}, {0, 0, 0}, {0, 1, 0}) *
       impeller::Matrix::MakeScale({0.3, 0.3, 0.3}) *
       impeller::Matrix::MakeRotationY(impeller::Radians{-0.4f * time}) *
       impeller::Matrix::MakeRotationZ(

--- a/src/examples/mesh/mesh_example.cc
+++ b/src/examples/mesh/mesh_example.cc
@@ -146,12 +146,13 @@ bool MeshExample::Setup(impeller::Context& context) {
   pipeline_desc->SetSampleCount(impeller::SampleCount::kCount4);
   pipeline_desc->SetWindingOrder(impeller::WindingOrder::kCounterClockwise);
   pipeline_desc->SetCullMode(impeller::CullMode::kBackFace);
-  pipeline_desc->SetDepthStencilAttachmentDescriptor({
+  pipeline_desc->SetDepthStencilAttachmentDescriptor(
+    std::make_optional<impeller::DepthAttachmentDescriptor>({
       .depth_compare = impeller::CompareFunction::kLess,
       .depth_write_enabled = true,
-  });
+    }));
   pipeline_ =
-      context.GetPipelineLibrary()->GetPipeline(pipeline_desc).get();
+      context.GetPipelineLibrary()->GetPipeline(pipeline_desc).Get();
   if (!pipeline_ || !pipeline_->IsValid()) {
     std::cerr << "Failed to initialize pipeline for mesh example.";
     return false;

--- a/src/examples/the_impeller/the_impeller_example.cc
+++ b/src/examples/the_impeller/the_impeller_example.cc
@@ -59,7 +59,7 @@ bool TheImpellerExample::Setup(impeller::Context& context) {
   auto pipeline_desc =
       impeller::PipelineBuilder<VS, FS>::MakeDefaultPipelineDescriptor(context);
   pipeline_desc->SetSampleCount(impeller::SampleCount::kCount4);
-  pipeline_ = context.GetPipelineLibrary()->GetPipeline(pipeline_desc).get();
+  pipeline_ = context.GetPipelineLibrary()->GetPipeline(pipeline_desc).Get();
   if (!pipeline_ || !pipeline_->IsValid()) {
     std::cerr << "Failed to initialize pipeline for showcase.";
     return false;

--- a/src/main_gles.cc
+++ b/src/main_gles.cc
@@ -231,8 +231,7 @@ int main() {
       {
         impeller::TextureDescriptor depth_texture_desc;
         depth_texture_desc.type = impeller::TextureType::kTexture2D;
-        
-        // XXX: Might be wrong; mesh example doesn't render anything.
+
         depth_texture_desc.format = impeller::PixelFormat::kD32FloatS8UInt; //DefaultColor;
         depth_texture_desc.size = render_target.GetRenderTargetSize();
         depth_texture_desc.usage = static_cast<impeller::TextureUsageMask>(

--- a/src/main_gles.cc
+++ b/src/main_gles.cc
@@ -231,7 +231,9 @@ int main() {
       {
         impeller::TextureDescriptor depth_texture_desc;
         depth_texture_desc.type = impeller::TextureType::kTexture2D;
-        depth_texture_desc.format = impeller::PixelFormat::kDefaultColor;
+        
+        // XXX: Might be wrong; mesh example doesn't render anything.
+        depth_texture_desc.format = impeller::PixelFormat::kD32FloatS8UInt; //DefaultColor;
         depth_texture_desc.size = render_target.GetRenderTargetSize();
         depth_texture_desc.usage = static_cast<impeller::TextureUsageMask>(
             impeller::TextureUsage::kRenderTarget);


### PR DESCRIPTION
This change doesn't quite work -- the mesh example only seems to show the clear color now, but TheImpeller example renders OK.