### PR TITLE
Add a preset and toolchain for building on Flutter CI

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-    "version": 2,
+    "version": 3,
     "configurePresets": [
         {
             "name": "ninja-debug-vs2022",
@@ -29,6 +29,19 @@
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++",
                 "CMAKE_CXX_LINKER": "ld"
+            }
+        },
+        {
+            "name": "flutter-ci-mac-debug-x64",
+            "displayName": "Flutter CI mac-debug-x64",
+            "description": "Goma-enabled Ninja build for Flutter CI",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/out/build/mac-debug-x64",
+            "toolchainFile": "${sourceDir}/toolchains/mac-x64-toolchain.cmake",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "1"
             }
         }
     ],

--- a/imgui.cmake
+++ b/imgui.cmake
@@ -1,4 +1,10 @@
-set(IMGUI_IMPELLER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/impeller-cmake/third_party/flutter/impeller/playground/imgui)
+if(DEFINED FLUTTER_ENGINE_DIR)
+    set(IMGUI_FLUTTER_DIR ${FLUTTER_ENGINE_DIR})
+else()
+    set(IMGUI_FLUTTER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/impeller-cmake/third_party/flutter)
+endif()
+set(IMGUI_IMPELLER_DIR ${IMGUI_FLUTTER_DIR}/impeller/playground/imgui)
+
 add_gles_shader_library(
     NAME imgui
     SHADERS
@@ -25,6 +31,6 @@ target_include_directories(imgui
         ${CMAKE_CURRENT_SOURCE_DIR} # For "third_party/*"
         ${CMAKE_CURRENT_SOURCE_DIR}/third_party # For "imgui/*"
         ${CMAKE_CURRENT_SOURCE_DIR}/third_party/imgui # For "imgui.h"
-        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/impeller-cmake/third_party/flutter # For "impeller/*"
+        ${IMGUI_FLUTTER_DIR} # For "impeller/*"
         ${GENERATED_DIR})
 target_link_libraries(imgui PUBLIC glfw impeller_renderer)

--- a/toolchains/mac-x64-toolchain.cmake
+++ b/toolchains/mac-x64-toolchain.cmake
@@ -1,0 +1,53 @@
+# This toolchain definition expects the environment variable
+# FLUTTER_ENGINE_SRC_DIR to be the absolute path to a full Flutter engine
+# checkout.
+#
+# Optionally, the enviornment variable FLUTTER_GOMA_DIR may be set to the
+# absolute path to the `gomacc` binary. Googlers can use this to do a Goma
+# accelerated build.
+#
+# For the Goma accelerated build to work locally (that is, outside of the
+# CI environment), the environment variable FLUTTER_OSX_SYSROOT should be set
+# to the path that results from the script:
+#
+# $ flutter/engine/src/build/mac/find_sdk.py --print_sdk_path 10.15 --symlink xcode-sysroot
+#
+# From a Flutter engine checkout, and `xcode-sysroot` is the desired location
+# of the symlink that the script creates. Set FLUTTER_OSX_SYSROOT to
+# the absolute path to `xcode-sysroot`.
+
+set(FLUTTER_ENGINE_SRC_DIR "$ENV{FLUTTER_ENGINE_SRC_DIR}")
+if(NOT FLUTTER_ENGINE_SRC_DIR OR NOT IS_DIRECTORY "${FLUTTER_ENGINE_SRC_DIR}")
+    message(SEND_ERROR
+        "Unable to configure any targets because the Flutter Engine directory "
+        "(FLUTTER_ENGINE_SRC_DIR) couldn't be found: "
+        "    '${FLUTTER_ENGINE_SRC_DIR}'")
+    return()
+endif()
+
+set(FLUTTER_ENGINE_SRC_DIR "$ENV{FLUTTER_ENGINE_SRC_DIR}")
+set(FLUTTER_ENGINE_DIR "${FLUTTER_ENGINE_SRC_DIR}/flutter")
+
+set(TOOLCHAIN_BIN_DIR "${FLUTTER_ENGINE_SRC_DIR}/buildtools/mac-x64/clang/bin")
+set(CMAKE_C_COMPILER "${TOOLCHAIN_BIN_DIR}/clang")
+set(CMAKE_CXX_COMPILER "${TOOLCHAIN_BIN_DIR}/clang++")
+set(CMAKE_CXX_LINKER "${TOOLCHAIN_BIN_DIR}/clang++")
+set(CMAKE_AR "${TOOLCHAIN_BIN_DIR}/llvm-ar")
+add_compile_options("-Wno-deprecated-builtins")
+
+set(FLUTTER_GOMA_DIR "$ENV{FLUTTER_GOMA_DIR}")
+if(FLUTTER_GOMA_DIR)
+    set(CMAKE_C_COMPILER_LAUNCHER "${FLUTTER_GOMA_DIR}/gomacc")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${FLUTTER_GOMA_DIR}/gomacc")
+endif()
+
+set(FLUTTER_OSX_SYSROOT "$ENV{FLUTTER_OSX_SYSROOT}")
+if(FLUTTER_OSX_SYSROOT)
+    set(CMAKE_OSX_SYSROOT "${FLUTTER_OSX_SYSROOT}")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15")
+    set(CMAKE_MACOSX_RPATH "1")
+
+    add_compile_options("-nostdinc++")
+    include_directories("${CMAKE_OSX_SYSROOT}/usr/include/c++/v1")
+    add_link_options("-L${CMAKE_OSX_SYSROOT}/usr/lib")
+endif()


### PR DESCRIPTION
My CMake is very rusty, so I'm not sure if this is the best way to do this, but it looks like by bumping the preset file version up to 3, I can pull out a bunch of the Flutter CI specific bits into the new file `toolchains/mac-x64-toolchain.cmake`.

cc @bdero 