### PR TITLE
Change clang version for github build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ master ]
   workflow_dispatch:
 
 # Declare default permissions as read only.
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -30,7 +30,7 @@ jobs:
     - name: Install LLVM and Clang
       uses: KyleMayes/install-llvm-action@v1
       with:
-        version: "16.0.0"
+        version: "15"
 
     - name: Get cmake and ninja
       uses: lukka/get-cmake@v3.26.0

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -28,7 +28,8 @@
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "1",
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_CXX_LINKER": "ld"
+                "CMAKE_CXX_LINKER": "ld",
+                "CMAKE_AR": "llvm-ar"
             }
         },
         {


### PR DESCRIPTION
Reading the script, "15" should hit a supported version of clang on macOS.

This also changes the target branch names that should trigger the actions to explicitly be the default branch name.